### PR TITLE
Obtain API key from custom variable (getter) and expose package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # emacs-gpt
+
+## Usage
+
+Invoke any of the `gpt-elisp` interactive commands using `M-x` (Meta-X or Alt-X) on your system and typing out the instruction that you want the machine to resolve.
+
+## Installation
+
+```emacs-lisp
+(use-package gpt-elisp
+  :straight (gpt-elisp :type git
+                       :host github
+                       :repo "beguene/emacs-gpt")
+  :custom
+  (gpt-elisp-edit-api-key-getter (lambda () "sk-XXX")))
+```
+
+## Configuration
+
+Before you use the package, configure your OpenAI API key by setting the `gpt-elisp-edit-api-key-getter`:
+
+``` emacs-lisp
+(setq gpt-elisp-edit-api-key-getter (lambda () "sk-XXX"))
+```
+
+### Using password-store to retrieve your OpenAI key
+
+Instead of specifying your API key in source or loading it from another file, you can configure auth-source to use [password store](https://www.passwordstore.org/) as a backend.
+
+Non straight.el users, can enable auth-source through the following call:
+
+```emacs-lisp
+(auth-source-pass-enable)
+```
+
+Straight.el users, can load and configuration the *auth-source* package as follows:
+
+```emacs-lisp
+(use-package auth-source
+  :straight (:type built-in)
+
+  :config
+  (auth-source-pass-enable))
+```
+
+
+After loading auth-source, you can define the `gpt-elisp-edit-api-key-getter` custom variable to retrieve the password from your password store:
+
+```emacs-lisp
+(customize-set-variable
+  'gpt-elisp-edit-api-key-getter
+  (lambda ()
+    (auth-source-pass-get 'secret "openai.com/user-handle/api-key")))
+```
+
+or again, when using straight.el:
+
+```emacs-lisp
+(use-package gpt-elisp
+  :straight (aide :type git
+                  :host github
+                  :repo "beguene/emacs-gpt")
+  :custom
+  (gpt-elisp-edit-api-key-getter (lambda ()
+                                   (auth-source-pass-get 'secret "openai.com/user-handle/api-key"))))
+```
+

--- a/emacs-gpt.el
+++ b/emacs-gpt.el
@@ -26,6 +26,11 @@
 
 (require 'request)
 
+(defgroup gpt-elisp-edit nil
+  "gpt-elisp.el custom settings"
+  :group 'gpt-elisp-edit
+  :prefix "gpt-elisp-edit-")
+
 (defcustom gpt-elisp-edit-api-key-getter (lambda () "sk-XXX")
   "API key for OpenAI"
   :type 'function
@@ -92,3 +97,5 @@
   (if (derived-mode-p 'prog-mode)
       (gpt-elisp-edit-generic "code-davinci-edit-001" instruction t)
       (gpt-elisp-edit-generic "text-davinci-edit-001" instruction t)))
+
+(provide 'gpt-elisp)


### PR DESCRIPTION
Just abstracted the API key setting bit away into a function that end-users can specify through Emacs's customization facility. I use this as well for https://github.com/junjizhi/aide.el/pull/6 but I recognize that this may not be helpful at all to you and other users.

Probably just a best-practice to source passwords from a pass-store but not a must.

In case you consider this an unmergeable mess, pls clarify in which ways this completely conflicts with your intentions for this package and I'll try to step up and clean up or just butt out. 😉 

Nice work on the package. I'll be experimenting with this over the next days. 🙏🏿 